### PR TITLE
Reference types in export declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,10 +158,12 @@
   "main": "edition-es2019/index.js",
   "exports": {
     "node": {
+      "types": "./compiled-types/index.d.ts",
       "import": "./edition-es2019-esm/index.js",
       "require": "./edition-es2019/index.js"
     },
     "browser": {
+      "types": "./compiled-types/index.d.ts",
       "import": "./edition-browsers/index.js"
     }
   },


### PR DESCRIPTION
There are typescript errors when using this package with typescript 4.7 and es-modules enabled.
The error message you're getting is:

```
Could not find a declaration file for module 'get-current-line'. '/home/lrd900/triply/ratt/node_modules/get-current-line/edition-es2019-esm/index.js' implicitly has an 'any' type.
```

The typescript docs says we should add a types references to the esm exports declaration in the package.json file. (See [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing).

This PR does that
