### PR TITLE
Add types resolutions to package.json exports field to support NodeNext/Node16 module resolution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,10 +159,12 @@
   "exports": {
     "node": {
       "import": "./edition-es2019-esm/index.js",
-      "require": "./edition-es2019/index.js"
+      "require": "./edition-es2019/index.js",
+      "types": "./compiled-types/index.d.ts"
     },
     "browser": {
-      "import": "./edition-browsers/index.js"
+      "import": "./edition-browsers/index.js",
+      "types": "./compiled-types/index.d.ts"
     }
   },
   "deno": "edition-deno/index.ts",


### PR DESCRIPTION
Hey there! First of all wanted to thank you for building this very useful and underappreciated library :-) It's clear how much care was put into ensuring it works across all flavors of JS in the JS/TS ecosystem!


TS 4.7 added "NodeNext" and "Node16" as possible settings for "compilerOptions/moduleResolution" in `tsconfig.json`.

If either of these settings are used, TS is no longer enable to resolve the types for `get-current-line`: 

![image](https://user-images.githubusercontent.com/10645823/190460457-abdc6a54-69b9-45f1-9756-30f26d3d3d1e.png)

As a temporary workaround, I explicitly added `get-current-line`'s types to my tsconfig's mapped "paths":

```json
{
    "extends": "../../tsconfig",
    "compilerOptions": {
        "paths": {
            "get-current-line": [
                "./node_modules/get-current-line/compiled-types/index.d.ts"
            ]
        }
    }
}
```

Unfortunately, this kind of problem can be quite tricky to resolve for developers who are relatively new to the quirks of Node/TypeScript's module resolution behavior.

I added a reference to the package's types in the `package.json` "exports" map, and, based on some very superficial testing, the types appear to be resolvable in all Node environments by default. I'm not sure what impact this might have in non-Node environments, but none seems like a safe assumption (or at least nothing should break 🤣).

Thanks again for the great work, and wishing you all the best!